### PR TITLE
executable-spec: implemented a more realistic commit-reveal scheme

### DIFF
--- a/executable-spec/decentralized-updates.cabal
+++ b/executable-spec/decentralized-updates.cabal
@@ -21,6 +21,8 @@ library
                      , generic-monoid
                      , bimap >= 0.4.0
                      , hedgehog >= 1.0
+                     , text
+                     , hashable
                      -- Local deps
                      , small-steps
                      , cs-ledger

--- a/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Data.hs
+++ b/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Data.hs
@@ -86,7 +86,7 @@ instance Core.HasHash (SIPData) where
 -- | System improvement proposal
 data SIP =
   SIP { --id :: !UpId
-      -- ^ Submission proposal id.
+        -- Submission proposal id.
         sipHash :: !Core.Hash
       -- ^ Hash of the SIP contents (`SIPData`)
       -- also plays the role of a SIP unique id

--- a/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Data.hs
+++ b/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Data.hs
@@ -7,7 +7,7 @@
 
 module Cardano.Ledger.Spec.STS.Update.Data where
 
---import Data.Word (Word64)
+import Data.Word (Word64)
 import           Data.Monoid.Generic (GenericMonoid (GenericMonoid),
                      GenericSemigroup (GenericSemigroup))
 import           Data.Set (Set)
@@ -21,7 +21,7 @@ import           Data.Map.Strict (Map)
 
 
 -- |A unique ID of a software update
-newtype UpId = UpId { getUpId :: Integer --Word64
+newtype UpId = UpId { getUpId :: Word64
                     }
   deriving (Show, Eq, Ord, Hashable, Generic)
 

--- a/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Data.hs
+++ b/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Data.hs
@@ -1,29 +1,130 @@
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
 
 module Cardano.Ledger.Spec.STS.Update.Data where
 
-import Data.Word (Word64)
+--import Data.Word (Word64)
 import           Data.Monoid.Generic (GenericMonoid (GenericMonoid),
                      GenericSemigroup (GenericSemigroup))
 import           Data.Set (Set)
 import           GHC.Generics (Generic)
-
+import           Data.Text (Text)
+import           Numeric.Natural (Natural)
+import           Data.Hashable (Hashable)
+import qualified Data.Hashable as H
 import qualified Ledger.Core as Core
+import           Data.Map.Strict (Map)
+
+
+-- |A unique ID of a software update
+newtype UpId = UpId { getUpId :: Integer --Word64
+                    }
+  deriving (Show, Eq, Ord, Hashable, Generic)
+
+instance Core.HasHash (UpId) where
+  hash (UpId i) = Core.Hash $ H.hash i
+
+instance Num UpId where
+  (+) a b = UpId $ (getUpId a) + (getUpId b)
+
+-- | Protocol version
+data ProtVer = ProtVer
+  { _pvMaj :: Natural
+  , _pvMin :: Natural
+  , _pvAlt :: Natural
+  } deriving (Eq, Generic, Ord, Show, Hashable)
+
+-- | Application version
+newtype ApVer = ApVer Natural
+  deriving stock (Generic, Show)
+  deriving newtype (Eq, Ord, Num, Hashable)
+
+-- | Consensus Protocol Parameter Name
+data ParamName =
+    BlockSizeMax
+  | TxSizeMax
+  | SlotSize
+  | EpochSize
+  deriving (Eq, Generic, Ord, Show, Hashable)
+
+-- | Metadata structure for SIP
+data SIPMetadata =
+  SIPMetadata { versionFrom :: (ProtVer, ApVer)
+                -- ^ The version the this SIP has been based on
+              , versionTo :: (ProtVer, ApVer)
+              -- ^ the version after the SIP takes effect
+              , impactsConsensus :: Bool
+              -- ^ Flag to determine an impact on the underlying consensus protocol
+              , impactsParameters :: [ParamName]
+              -- ^ List of protocol parameters impacted
+              } deriving (Eq, Generic, Ord, Show, Hashable)
+
+-- | Contents of a SIP
+data SIPData =
+  SIPData {  url :: Text
+            -- ^ URL pointing at the SIP
+          , metadata :: SIPMetadata
+            -- ^ SIP Metadata
+          }
+  | NullSIPData
+  deriving (Eq, Generic, Ord, Show, Hashable)
+
+instance Core.HasHash (SIPData) where
+  hash a = Core.Hash $ H.hash a
 
 -- | System improvement proposal
 data SIP =
-  SIP { id :: Word64
+  SIP { id :: UpId
       -- ^ Submission proposal id.
+      , sipHash :: Core.Hash
+      -- ^ Hash of the SIP contents (`SIPData`)
       , author :: Core.VKey
       -- ^ Who submitted the proposal.
+      , salt :: Int
+      -- ^ The salt used during the commit phase
       }
+  deriving (Eq, Generic, Ord, Show, Hashable)
+
+instance Core.HasHash (SIP) where
+  hash a = Core.Hash $ H.hash a
+
+-- | A commitment data type.
+-- It is the `hash` $ salt ++ sip_owner_pk ++ `hash` `SIP`
+newtype Commit = Commit { getCommit :: Core.Hash}
+  deriving (Show, Eq, Ord)
+
+-- | The System improvement proposal at the commit phase
+data SIPCommit =
+  SIPCommit { _commit :: Commit
+            -- ^ A salted commitment (a hash) to the SIP id, the public key
+            -- and the `hash` `SIP` (H(salt||pk||H(SIP)))
+            , _author :: Core.VKey
+            -- ^ Who submitted the proposal.
+            , _upSig :: Core.Sig Commit
+            -- ^ A signature on commit by the author public key
+            }
   deriving (Eq, Show, Ord)
+
+-- | Calculate a `Commit` from a `SIP`
+calcCommit :: SIP -> Commit
+calcCommit sip =
+  Commit $
+    Core.hash $
+      -- Limit calculation of commit only to the id and author field, otherwise you dont get a match at reveal signal!
+      --(myshow . salt $ sip)
+      (myshow . Cardano.Ledger.Spec.STS.Update.Data.id $ sip)
+      `mappend` (myshow . author $ sip)
+      --`mappend` (myshow . Core.hash $ sip)
 
 -- | Ideation phase state
 data State
   = State
-    { submittedSIPs :: !(Set SIP)
+    { commitedSIPs :: !(Map Commit SIPCommit)
+    , submittedSIPs :: !(Set SIP)
     , revealedSIPs :: !(Set SIP)
     }
   deriving (Eq, Show, Generic)
@@ -32,6 +133,23 @@ data State
 
 -- | Ideation signals.
 data Signal
-  = Submit SIP
+  = Submit SIPCommit SIP
   | Reveal SIP
   deriving (Eq, Ord, Show)
+
+-- | A newtype string that is an instance of `HasHash`
+newtype MyString = MyString { str :: String }
+  deriving (Eq, Generic, Ord, Show)
+
+instance Core.HasHash (MyString) where
+  hash (MyString s) = Core.Hash $ H.hash s
+
+instance Semigroup (MyString) where
+  (<>) (MyString s1) (MyString s2) = MyString (s1 ++ s2)
+
+instance Monoid (MyString) where
+  mempty = MyString ""
+
+-- | A `show` of `MyString`
+myshow :: Show a => a -> MyString
+myshow a = MyString $ show a

--- a/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Ideation.hs
+++ b/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Ideation.hs
@@ -87,6 +87,7 @@ instance STS IDEATION where
           --   Nothing -> False
           --   Just _ -> True
           --   ?! SIPFailedToBeRevealed sip
+          --
           (Data.calcCommit sip) ∈ (dom commitedSIPs) ?! SIPFailedToBeRevealed sip
           pure st { submittedSIPs = Set.delete sip submittedSIPs
                   , revealedSIPs = Set.insert sip revealedSIPs

--- a/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Ideation.hs
+++ b/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Ideation.hs
@@ -1,16 +1,18 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE BangPatterns #-}
 
 module Cardano.Ledger.Spec.STS.Update.Ideation where
 
 import           Control.Arrow ((&&&))
 import           Control.Monad (mzero)
-import           Data.Bimap (Bimap)
+import           Data.Bimap (Bimap, (!))
 import qualified Data.Bimap as Bimap
 import qualified Data.Set as Set
 import           Hedgehog ()
 import qualified Hedgehog.Gen as Gen
+import           Hedgehog.Range (constant)
 
 import           Control.State.Transition (Environment, PredicateFailure, STS,
                      Signal, State, TRC (TRC), initialRules, judgmentContext,
@@ -18,12 +20,14 @@ import           Control.State.Transition (Environment, PredicateFailure, STS,
 import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 
 import           Cardano.Ledger.Spec.STS.Update.Data (Signal (Reveal, Submit),
-                     revealedSIPs, submittedSIPs)
+                      SIPData(..), revealedSIPs, submittedSIPs, commitedSIPs)
 import           Cardano.Ledger.Spec.STS.Update.Data (author)
 import qualified Cardano.Ledger.Spec.STS.Update.Data as Data
 
-import           Ledger.Core (dom, (∈), (∉))
+import           Ledger.Core (dom, (∈), (∉), hash)
 import qualified Ledger.Core as Core
+import qualified Data.Map.Strict as Map
+--import qualified Debug.Trace as Debug
 
 --------------------------------------------------------------------------------
 -- Updates ideation phase
@@ -51,6 +55,7 @@ instance STS IDEATION where
     | NoSIPToReveal Data.SIP
     | SIPAlreadyRevealed Data.SIP
     | InvalidAuthor Core.VKey
+    | SIPFailedToBeRevealed Data.SIP
     deriving (Eq, Show)
 
   initialRules = [ pure $! mempty ]
@@ -58,23 +63,33 @@ instance STS IDEATION where
   transitionRules = [
     do
       TRC ( participants
-          , st@Data.State { submittedSIPs, revealedSIPs }
+          , st@Data.State { commitedSIPs, submittedSIPs, revealedSIPs }
           , sig
           ) <- judgmentContext
       case sig of
-        Submit sip -> do
+        Submit sipc sip -> do
           author sip ∈ dom participants ?! InvalidAuthor (author sip)
           sip ∉ submittedSIPs ?! SIPAlreadySubmitted sip
-          pure $! st { submittedSIPs = Set.insert sip submittedSIPs }
+          pure $! st { commitedSIPs = Map.insert (Data._commit sipc) (sipc) commitedSIPs
+                     , submittedSIPs = Set.insert sip submittedSIPs
+                     }
         Reveal sip -> do
           author sip ∈ dom participants ?! InvalidAuthor (author sip)
           sip ∈ submittedSIPs ?! NoSIPToReveal sip
           sip ∉ revealedSIPs ?! SIPAlreadyRevealed sip
+
+          -- debug
+          -- let !dummy3 = Debug.trace ("calcCommit: " ++ show (Data.calcCommit sip)) True
+          --     !dummy4 = Debug.trace ("LookUpCommit: " ++ show (Map.lookup (Data.calcCommit sip) commitedSIPs)) True
+
+          case Map.lookup (Data.calcCommit sip) commitedSIPs of
+            Nothing -> False
+            Just _ -> True
+            ?! SIPFailedToBeRevealed sip
           pure st { submittedSIPs = Set.delete sip submittedSIPs
                   , revealedSIPs = Set.insert sip revealedSIPs
                   }
     ]
-
 
 instance HasTrace IDEATION where
 
@@ -92,26 +107,61 @@ instance HasTrace IDEATION where
   sigGen
     _maybePredicateFailure
     participants
-    Data.State { submittedSIPs, revealedSIPs }
-    =
-    Gen.frequency [ (1, generateASubmission)
-                  , (1, generateARevelation)
-                  ]
-    where
-      -- Generate a submission taking a participant that hasn't submitted a proposal yet
-      generateASubmission
-        = fmap (Submit . (nextId `Data.SIP`))
-        $ Gen.element
-        $ Set.toList
-        $ dom participants
-        where
-          nextId = maximum $ 0 : fmap (1+) ids
-          ids =  Set.toList (Set.map Data.id submittedSIPs)
-              ++ Set.toList (Set.map Data.id revealedSIPs)
+    Data.State { submittedSIPs, revealedSIPs } = do
+      owner <- newOwner
+      Gen.frequency [ (1, generateASubmission owner)
+                    , (1, generateARevelation)
+                    ]
 
-      generateARevelation =
-        case Set.toList submittedSIPs of
-          [] -> mzero -- We cannot generate a revelation, since there are no
-                      -- (SIP) commitments yet, so we retry (in this case
-                      -- eventually we'll generate a submission).
-          xs -> fmap Reveal $ Gen.element xs
+      where
+        !newOwner = -- (fmap (Data.author) newSIP)
+          Gen.element
+          $ Set.toList
+          $ dom participants
+
+        -- Generate a submission taking a participant that hasn't submitted a proposal yet
+        generateASubmission owner = do
+          -- debug
+          -- ncommit <- newCommit
+          -- let
+          --   !dummy1 = Debug.trace ("owner: " ++ show owner) True
+          --   !dummy2 = Debug.trace ("newCommit: " ++ show ncommit) True
+
+          (Submit)
+            <$>
+              ((Data.SIPCommit) <$> newCommit <*> (pure owner) <*> newSignature)
+            <*>
+              (newSIP)
+          where
+            newSignature = (Core.sign) <$> skey <*> newCommit
+
+            newCommit = fmap (Data.calcCommit) newSIP
+              -- fmap (Data.Commit) $
+              --   fmap (hash) $ -- newSIP
+              --   (++) <$> (fmap (show . Data.salt) newSIP) <*> (
+              --    (++) <$> (fmap (show) (pure owner)) <*> (fmap (show . hash) newSIP)
+              --   )
+
+            -- Do a Bimap lookup to get the sk from the vk
+            skey = (!) <$>  (pure participants) <*> (pure owner)
+
+            newSIP =
+              ( <*> newSalt)
+              $ fmap (Data.SIP nextId newHash)
+              $ pure owner
+              -- $ Gen.element
+              -- $ Set.toList
+              -- $ dom participants
+              where
+                nextId = maximum $ (Data.UpId 0) : fmap ((Data.UpId 1)+) ids
+                ids =  Set.toList (Set.map Data.id submittedSIPs)
+                    ++ Set.toList (Set.map Data.id revealedSIPs)
+                newSalt = Gen.int (constant 0 100)
+                newHash = hash NullSIPData
+
+        generateARevelation =
+          case Set.toList submittedSIPs of
+            [] -> mzero -- We cannot generate a revelation, since there are no
+                        -- (SIP) commitments yet, so we retry (in this case
+                        -- eventually we'll generate a submission).
+            xs -> fmap Reveal $ Gen.element xs

--- a/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Ideation.hs
+++ b/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Ideation.hs
@@ -78,7 +78,7 @@ instance STS IDEATION where
           author sip ∈ dom participants ?! InvalidAuthor (author sip)
           sip ∈ submittedSIPs ?! NoSIPToReveal sip
           sip ∉ revealedSIPs ?! SIPAlreadyRevealed sip
-
+          --
           -- debug
           -- let !dummy3 = Debug.trace ("calcCommit: " ++ show (Data.calcCommit sip) ++ " " ++ (show $ Data.salt sip)) True
           --     !dummy4 = Debug.trace ("LookUpCommit: " ++ show (Map.lookup (Data.calcCommit sip) commitedSIPs)) True

--- a/nix/.stack.nix/decentralized-updates.nix
+++ b/nix/.stack.nix/decentralized-updates.nix
@@ -22,6 +22,8 @@
           (hsPkgs.generic-monoid)
           (hsPkgs.bimap)
           (hsPkgs.hedgehog)
+          (hsPkgs.text)
+          (hsPkgs.hashable)
           (hsPkgs.small-steps)
           (hsPkgs.cs-ledger)
           ];


### PR DESCRIPTION
Implemented a SIPCommit data type for the commit phase. At the reveal phase, a match on the calculated commit (from the revealed SIP) with the commit stored in the State, must take place, otherwise a SIPFailedToBeRevealed error occurs.

I had some problems with the commit matching at the reveal phase, so I ended up simplifying the calculation of the commit (Data.calcCommit). 