### PR TITLE
Trace related stuff

### DIFF
--- a/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Data.hs
+++ b/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Data.hs
@@ -116,24 +116,9 @@ stakePercentRound st totSt =
 newtype Stake = Stake { getStake :: Word64 }
  deriving newtype (Eq, Ord, Show, Enum, Num, Integral, Real, Random)
 
--- | Duration of a Voting Period
-data VPDuration = VPMin | VPMedium | VPLarge
-  deriving (Eq, Ord, Show, Generic, HasTypeReps)
-
 -- | Voting Period status values
 data VPStatus = VPOpen | VPClosed
   deriving (Eq, Ord, Show)
-
--- | Includes logic to translate a voting period duration
--- to number of slots
--- TODO: Change VPDuration from bands to actual SlotCounts
--- without any "translation logic"
-vpDurationToSlotCnt :: VPDuration -> SlotCount
-vpDurationToSlotCnt  d =
-  case d of
-    VPMin -> SlotCount 20
-    VPMedium -> SlotCount 40
-    VPLarge -> SlotCount 80
 
 -- | Protocol version
 --
@@ -175,10 +160,8 @@ data SIPMetadata =
     , impactsParameters :: !([ParamName])
       -- ^ List of protocol parameters impacted
 
-    , votPeriodDuration :: !VPDuration
+    , votPeriodDuration :: !SlotCount -- !VPDuration
       -- ^ Voting Period duration for this SIP
-      -- TODO: Change VPDuration from bands to actual SlotCounts
-      -- without any "translation logic"
     }
   deriving (Eq, Generic, Ord, Show, HasTypeReps)
 

--- a/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Data.hs
+++ b/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Data.hs
@@ -27,7 +27,7 @@ import           System.Random (Random)
 import           Cardano.Binary (ToCBOR (toCBOR), encodeInt, encodeListLen)
 
 import           Data.AbstractSize (HasTypeReps, typeReps)
-import           Ledger.Core (SlotCount (SlotCount))
+import           Ledger.Core (SlotCount)
 
 import           Cardano.Ledger.Spec.Classes.Hashable (HasHash, Hash, Hashable,
                      hash)
@@ -160,7 +160,7 @@ data SIPMetadata =
     , impactsParameters :: !([ParamName])
       -- ^ List of protocol parameters impacted
 
-    , votPeriodDuration :: !SlotCount -- !VPDuration
+    , votPeriodDuration :: !SlotCount
       -- ^ Voting Period duration for this SIP
     }
   deriving (Eq, Generic, Ord, Show, HasTypeReps)

--- a/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Ideation.hs
+++ b/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Ideation.hs
@@ -267,7 +267,7 @@ instance STS.Gen.HasTrace (IDEATION Mock) a where
                                      , Data.SlotSize
                                      , Data.EpochSize
                                      ]
-                    <*> (SlotCount <$> QC.choose (10, 100))
+                    <*> (SlotCount <$> QC.choose (5, 30))
                     where
                       versionFromGen = do
                         protVer <- word64Gen

--- a/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Ideation.hs
+++ b/executable-spec/src/Cardano/Ledger/Spec/STS/Update/Ideation.hs
@@ -27,7 +27,8 @@ import qualified Test.QuickCheck as QC
 import           Control.State.Transition (Environment, PredicateFailure, STS,
                      Signal, State, TRC (TRC), initialRules, judgmentContext,
                      transitionRules, (?!))
-import           Ledger.Core (dom, (∈), (∉), (▷<=), (-.), (*.), (⨃), (⋪), range, (◁), Slot, BlockCount, (▷>=))
+import           Ledger.Core (dom, (∈), (∉), (▷<=), (-.), (*.), (⨃), (⋪), range, (◁)
+                             , Slot, SlotCount (SlotCount), BlockCount, (▷>=))
 
 import qualified Control.State.Transition.Trace.Generator.QuickCheck as STS.Gen
 
@@ -266,7 +267,7 @@ instance STS.Gen.HasTrace (IDEATION Mock) a where
                                      , Data.SlotSize
                                      , Data.EpochSize
                                      ]
-                    <*> QC.elements [Data.VPMin, Data.VPMedium, Data.VPLarge]
+                    <*> (SlotCount <$> QC.choose (10, 100))
                     where
                       versionFromGen = do
                         protVer <- word64Gen

--- a/executable-spec/src/Cardano/Ledger/Spec/State/RevealedSIPs.hs
+++ b/executable-spec/src/Cardano/Ledger/Spec/State/RevealedSIPs.hs
@@ -30,8 +30,7 @@ votingPeriodEnd
   -> RevealedSIPs p
   -> Core.SlotCount
 votingPeriodEnd sipHash sipdb
-  = Data.vpDurationToSlotCnt
-  $ Data.votPeriodDuration
+  = Data.votPeriodDuration
   . Data.metadata
   . Data.sipPayload
   $ (sipdb ! sipHash)

--- a/executable-spec/test/Cardano/Ledger/Spec/STS/Chain/Chain/Properties.hs
+++ b/executable-spec/test/Cardano/Ledger/Spec/STS/Chain/Chain/Properties.hs
@@ -112,7 +112,7 @@ relevantCasesAreCovered
           $
         -- Lifecycle coverage:
         -- There is at least one proposal in every phase of the lifecycle
-        QC.cover 60
+        QC.cover 50
           (lifecycleCoverage traceSample)
           "The lifecycle of a software update is sufficently covered"
           $
@@ -144,7 +144,7 @@ relevantCasesAreCovered
           $
 
           -- There are no active SIPs with no votes
-        QC.cover 95
+        QC.cover 80
           ( let SIPsVoteResults (vresmap) = Chain.vresips
                                             $ Trace.lastState traceSample
             in not $ any(\vr ->
@@ -179,12 +179,12 @@ relevantCasesAreCovered
         QC.cover 80
           ( (pctSIPsInUpdPayload traceSample) >= 1
            &&
-            (pctSIPsInUpdPayload traceSample) <= 20
+            (pctSIPsInUpdPayload traceSample) <= 30
           )
           "a reasonable Pct of SIP submissions in Update Payload"
           $
         QC.cover 45
-          (pctSIPsTallyOutcome traceSample Data.Approved >= 5)
+          (pctSIPsTallyOutcome traceSample Data.Approved >= 2)
           "satisfactory pct of approved SIPs"
           $
 
@@ -208,7 +208,7 @@ relevantCasesAreCovered
           "satisfactory pct of SIPs in revoting NoMajority"
           $ True
   where
-    maxTraceLength = 200
+    maxTraceLength = 100
 
 extraTestsForTestDebugging :: QC.Property
 extraTestsForTestDebugging
@@ -266,7 +266,7 @@ extraTestsForTestDebugging
                                         ]
       $ True
   where
-    maxTraceLength = 200
+    maxTraceLength = 100
 
 
 

--- a/executable-spec/test/Cardano/Ledger/Spec/STS/Chain/Chain/Properties.hs
+++ b/executable-spec/test/Cardano/Ledger/Spec/STS/Chain/Chain/Properties.hs
@@ -18,7 +18,7 @@ import qualified Control.State.Transition.Trace as Trace
 import qualified Control.State.Transition.Trace.Generator.QuickCheck as STS.Gen
 
 import           Ledger.Core (BlockCount, dom, range, size, unBlockCount,
-                     unSlotCount)
+                     unSlotCount, SlotCount (SlotCount))
 
 import           Cardano.Ledger.Spec.State.SIPsVoteResults
                      (SIPsVoteResults (SIPsVoteResults))
@@ -278,7 +278,7 @@ extraTestsForTestDebugging
 getMinTraceLength :: BlockCount -> Word64
 getMinTraceLength k =
   let kval = unBlockCount k
-      minVotingDuration = unSlotCount $ Data.vpDurationToSlotCnt Data.VPMin
+      minVotingDuration = unSlotCount $ SlotCount 10
   in 2*kval + 2*kval + minVotingDuration + 2*kval
 
 -- | Returns the percent of Txs with a non-empty update payload in the input Trace

--- a/executable-spec/test/Main.hs
+++ b/executable-spec/test/Main.hs
@@ -23,17 +23,11 @@ main = defaultMain tests
         [ testProperty
             "Only valid traces are generated"
             Ideation.qc_onlyValidSignalsAreGenerated
-        , testProperty
-            "Trace lengths are classified"
-            Ideation.qc_traceLengthsAreClassified
         ]
     , testGroup "Chain properties"
       [ testProperty
           "Only valid traces are generated"
           Chain.qc_onlyValidSignalsAreGenerated
-      , testProperty
-          "Trace lengths are classified"
-          Chain.qc_traceLengthsAreClassified
       , testProperty
           "Trace reveals are classified"
           Chain.qc_revealsAreClassified


### PR DESCRIPTION
- Do trace length classification only once
- Explicit duration of voting period and not based on a band
- Use traces of length 100 instead of 200