### PR TITLE
Add GitHub action to build PDF and upload it as artifact for easy access

### DIFF
--- a/.github/workflows/build-and-publish-release.yaml
+++ b/.github/workflows/build-and-publish-release.yaml
@@ -1,0 +1,21 @@
+name: Build LaTeX document
+on: [push]
+
+jobs:
+  build_latex:
+    name: Build LaTeX document & upload as artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v1
+      - name: Compile LaTeX document
+        uses: xu-cheng/latex-action@master
+        with:
+          working_directory: formal-spec
+          root_file: decentralized-updates.tex
+      - name: Upload artifacts
+        if: success()
+        uses: actions/upload-artifact@v1
+        with:
+          name: decentralized-updates-${{ github.sha }}.zip
+          path: formal-spec/decentralized-updates.pdf


### PR DESCRIPTION
This PR adds GitHub Actions workflow that upon `push` event compiles the **LaTeX** files into PDF and uploads it as artifact to respective GitHub Action job; this enables people to read work in progress papers without having to install rather large **LaTeX** build environment locally. 