### PR TITLE
Link the compiled PDF of the spec in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,33 @@
-<h1 align="center">On decentralized software updates for blockchain systems.</h1>
+<h1 align="center">On decentralized software updates for blockchain systems</h1>
 
 <p align="center">
   <a href="https://buildkite.com/input-output-hk/decentralized-software-updates">
-    <img alt="Build Status" src="https://img.shields.io/buildkite/0400e4f455135087dc9f04095439712f6c0225226e9d2ab623?style=for-the-badge"/>
+    <img alt="Build Status" src="https://img.shields.io/buildkite/0400e4f455135087dc9f04095439712f6c0225226e9d2ab623/master?style=for-the-badge"/>
   </a>
   <a href="https://coveralls.io/github/input-output-hk/decentralized-software-updates?branch=master">
     <img alt="Coverage Status" src="https://img.shields.io/coveralls/github/input-output-hk/decentralized-software-updates?style=for-the-badge"/>
   </a>
 </p>
+
+This repository contains research output (papers, specifications, models, and
+executable software) about decentralized software updates for blockchain
+systems. Our research focuses on defining a protocol that covers the life cycle
+of software updates, which consists of:
+
+- ideation: the definition and specification of an update proposal, similar to
+  [Bitcoin](https://github.com/bitcoin/bips) or
+  [Ethereum](https://github.com/ethereum/EIPs) improvement proposals.
+- implementation: the actual implementation of improvement proposals.
+- activation: the activation of new software version across nodes in the
+  blockchain.
+
+
+This work is funded by the [Priviledge](https://priviledge-project.eu/) project,
+and these results will be incorporated into the
+[Voltaire](https://cardanoroadmap.com/en/voltaire/) release of Cardano.
+
+The research roadmap can be found in [our
+wiki](https://github.com/input-output-hk/decentralized-software-updates/wiki/Roadmap).
 
 ## Formal specification
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Formal specification
 
 The formal specification is written in `LaTeX`. It can be found in the
-[`formal-spec`](./formal-spec) folder.
+[`formal-spec`](./formal-spec) folder. A compiled pdf can be found [here](https://hydra.iohk.io/job/Cardano/decentralized-software-updates/decentralizedUpdatesSpec/latest/download-by-type/doc-pdf/decentralized-updates).
 
 We use [`nix`](https://nixos.org/nix/download.html) to achieve not only
 reproducible software builds, but also reproducible document builds across

--- a/formal-spec/decentralized-updates.tex
+++ b/formal-spec/decentralized-updates.tex
@@ -99,6 +99,7 @@ $}}}
 \tableofcontents
 \listoffigures
 
+\include{introduction}
 \include{requirements}
 \include{candidateproperties}
 \include{measurements}

--- a/formal-spec/introduction.tex
+++ b/formal-spec/introduction.tex
@@ -1,0 +1,24 @@
+\section{Introduction}
+\label{sec:introduction}
+
+
+\subsection{Scope}
+\label{sec:scope}
+
+In this specification we define an update protocol that covers the different
+phases of the software update process for blockchain systems. The following
+aspects are outside the scope of the current specification:
+
+\begin{description}
+\item[voting incentives] we assume that honest parties will participate in the
+  voting process. In addition, we use delegation as a means to ensure high
+  participation in the voting process. However, in reality an incentive
+  mechanism might be needed for ensuring this.
+\item[upgrade incentives] as with voting, parties might need an incentive for
+  upgrading to a new version of the software.
+\end{description}
+
+%%% Local Variables:
+%%% mode: latex
+%%% TeX-master: "decentralized-updates"
+%%% End:


### PR DESCRIPTION
The PDF version of the spec if already built in CI, but it wasn't linked from the README yet.

CC: @mark-stopka 