### PR TITLE
Property tests v2.0

### DIFF
--- a/.stack-to-nix.cache
+++ b/.stack-to-nix.cache
@@ -22,3 +22,4 @@ https://github.com/input-output-hk/cardano-prelude 3ac22a2fda11ca7131a011a9ea48f
 https://github.com/input-output-hk/cardano-ledger-specs c006b101b699b7b54a96d077fdbad07005b8da77 byron/semantics/executable-spec 1m2xs2z9bq83k65l2hx41zbj1akyl83cdlxhdxssd8nbmb723qar small-steps small-steps.nix
 https://github.com/input-output-hk/cardano-ledger-specs c006b101b699b7b54a96d077fdbad07005b8da77 byron/ledger/executable-spec 1m2xs2z9bq83k65l2hx41zbj1akyl83cdlxhdxssd8nbmb723qar cs-ledger cs-ledger.nix
 https://github.com/input-output-hk/cardano-base 0fcb3a306e96ce36fca75d62792c55ab1de871ea slotting 0fbcf3iim4fh8m647ilw02ybbxiqna3zpny0w7rlqjgd4skfqvjr cardano-slotting cardano-slotting.nix
+https://github.com/nomeata/haskell-successors 6f9f60eb3232b83cbffdc46301054c85983cf207 . 03jbs0730nyjhi01wqgmn6848pklvnzja7dv4nlhs1s6zb43gznx successors successors.nix

--- a/executable-spec/decentralized-updates.cabal
+++ b/executable-spec/decentralized-updates.cabal
@@ -58,6 +58,7 @@ library
                      -- Needed for 'Cardano.Ledger.Assert' only. We might want
                      -- to put this module on our test section.
                      , monad-validate
+                     , Unique
                      -- Needed for 'Cardano.Ledger.Debug' only.
                      , mtl
   default-language:    Haskell2010
@@ -85,6 +86,8 @@ test-suite ledger-rules-test
                      , Test.Cardano.Ledger.Update.UnitTests.Approval
                      , Test.Cardano.Ledger.Update.UnitTests.Activation
                      , Test.Cardano.Ledger.Update.UnitTests.Common
+                     -- Property tests
+                     , Test.Cardano.Ledger.Update.Properties
                      -- Test case specification
                      , Test.Cardano.Ledger.UpdateSpec
                      , Test.Cardano.Ledger.Update.TestCase
@@ -104,6 +107,7 @@ test-suite ledger-rules-test
                      , pretty-simple
                      , text
                      , random
+                     , successors
                      -- Cardano specific imports
                      , cardano-slotting
                      , decentralized-updates
@@ -117,6 +121,7 @@ test-suite ledger-rules-test
                        --
                        -- The 4 megabytes stack bound and 150 megabytes heap bound were
                        -- determined ad-hoc.
+                       --
                        "-with-rtsopts=-K1m -M150m"
                        -threaded
                        -rtsopts

--- a/executable-spec/src/Cardano/Ledger/Update.hs
+++ b/executable-spec/src/Cardano/Ledger/Update.hs
@@ -33,7 +33,8 @@ module Cardano.Ledger.Update
     -- ** Activation-state query functions
   , Activation.Endorsement (Endorsement, endorserId, endorsedVersion)
   , Activation.HasActivationState (getActivationState)
-  , Activation.getCurrentVersion
+  , Activation.getCurrentProtocol
+  , Activation.getCurrentProtocolVersion
   , Activation.isQueued
   , Activation.isBeingEndorsed
   , Activation.isScheduled

--- a/executable-spec/src/Cardano/Ledger/Update/Env/StakeDistribution.hs
+++ b/executable-spec/src/Cardano/Ledger/Update/Env/StakeDistribution.hs
@@ -12,9 +12,11 @@
 module Cardano.Ledger.Update.Env.StakeDistribution
   ( StakeDistribution
   , Stake (Stake)
+  , getStake
   , stakeMap
   , emptyStakeDistribution
   , fromList
+  , fromMap
   , totalStake
   , stakeOfKeys
   , stakeOfKeys'
@@ -114,18 +116,23 @@ fromList
   :: Ord k
   => [(k, Stake)]
   -> StakeDistribution k
-fromList xs
+fromList = fromMap . Map.fromList
+
+fromMap
+  :: Map k Stake
+  -> StakeDistribution k
+fromMap aStakeMap
   = checkInvariants
   $ StakeDistribution
-    { stakeMap   = Map.fromList xs
-    , totalStake = foldl' (+) 0 $ fmap snd xs
+    { stakeMap   = aStakeMap
+    , totalStake = foldl' (+) 0 $ Map.elems aStakeMap
     }
 
 --------------------------------------------------------------------------------
 -- Definitions
 --------------------------------------------------------------------------------
 
--- | Given a total stake and the adversary stake ratio, compute the how much
+-- | Given the adversary stake ratio and the total stake, compute the how much
 -- stake of this total stake is needed to meet the voting threshold.
 --
 -- This definition is based on 'vThreshold'. We have that the total stake needed
@@ -140,7 +147,9 @@ fromList xs
 stakeThreshold
   :: (RealFrac a)
   => a
+  -- ^ Adversary stake ratio
   -> Stake
+  -- ^ Total stake
   -> Stake
 stakeThreshold r_a totalStake =
   round $ 1/2 * (r_a + 1) * fromIntegral totalStake

--- a/executable-spec/src/Cardano/Ledger/Update/Env/TracksSlotTime.hs
+++ b/executable-spec/src/Cardano/Ledger/Update/Env/TracksSlotTime.hs
@@ -1,7 +1,7 @@
 module Cardano.Ledger.Update.Env.TracksSlotTime where
 
 import           GHC.Stack (HasCallStack)
-import           Control.Exception (assert)
+import Cardano.Ledger.Assert (assertAndReturn, (<=!), (<!))
 
 import Cardano.Slotting.Slot (SlotNo)
 
@@ -33,7 +33,6 @@ class TracksSlotTime e where
     epochFirstSlot e + slotsPerEpoch e
 
   checkInvariants :: HasCallStack => e -> e
-  checkInvariants e
-    = assert (epochFirstSlot e <= currentSlot e)
-    $ assert (currentSlot e < nextEpochFirstSlot e)
-    $ e
+  checkInvariants = assertAndReturn $ \e -> do
+    epochFirstSlot e <=! currentSlot e
+    currentSlot e <! nextEpochFirstSlot e

--- a/executable-spec/src/Cardano/Ledger/Update/ProposalsState.hs
+++ b/executable-spec/src/Cardano/Ledger/Update/ProposalsState.hs
@@ -34,7 +34,7 @@ module Cardano.Ledger.Update.ProposalsState
                            , Undecided
                            , WithNoQuorum
                            )
-  , ProposalState.VotingPeriod (VotingPeriod)
+  , ProposalState.VotingPeriod (VotingPeriod, unVotingPeriod)
   )
 where
 

--- a/executable-spec/test/Main.hs
+++ b/executable-spec/test/Main.hs
@@ -8,6 +8,7 @@ where
 import           Test.Tasty (TestTree, defaultMain, localOption, testGroup)
 import           Test.Tasty.Ingredients.ConsoleReporter (UseColor (Auto))
 
+import qualified Test.Cardano.Ledger.Update.Properties as Properties
 import qualified Test.Cardano.Ledger.Update.UnitTests.Activation as UnitTests.Activation
 import qualified Test.Cardano.Ledger.Update.UnitTests.Approval as UnitTests.Approval
 import qualified Test.Cardano.Ledger.Update.UnitTests.Ideation as UnitTests.Ideation
@@ -18,7 +19,8 @@ main = defaultMain tests
   tests :: TestTree
   tests = localOption Auto $ testGroup
     "Update"
-    [ testGroup "💡 Ideation phase unit tests" UnitTests.Ideation.runTests
-    , testGroup "👍 Approval phase unit tests" UnitTests.Approval.runTests
+    [ testGroup "💡 Ideation phase unit tests"  UnitTests.Ideation.runTests
+    , testGroup "👍 Approval phase unit tests"  UnitTests.Approval.runTests
     , testGroup "⚡ Activation phase unit tests" UnitTests.Activation.runTests
+    , testGroup "🎰 Property tests"             Properties.runTests
     ]

--- a/executable-spec/test/SUTTest.hs
+++ b/executable-spec/test/SUTTest.hs
@@ -42,10 +42,16 @@ class SUT s => TestGen s t where
   -- initial generator and SUT state.
   mkInitStates :: TestSetup t -> (GenSt t, SUTSt s)
 
-  -- | Try to generate an action based on the current state.
+  -- | Determine whether we can terminate the generation of action.
+  canTerminate :: GenSt t -> Bool
+
+  -- | Generate an action based on the current state. This generator should
+  -- always be able to return an action based on the given generator state.
+  -- Before calling 'genAct' the trace generation algorithm will call
+  -- 'canTerminate'. If no further actions can be generated in a given state
+  -- @st@, then @canTerminate st@ should hold.
   --
-  -- If an action cannot be generated 'Nothing' is returned.
-  genAct :: GenSt t -> Gen (Maybe (SUTAct s))
+  genAct :: TestSetup t -> GenSt t -> Gen (SUTAct s)
 
   -- | Update the generator state with the given SUT state.
   --
@@ -54,6 +60,3 @@ class SUT s => TestGen s t where
   -- > update (update genSt sutSt) sutSt == update genSt sutSt
   --
   update :: GenSt t -> SUTSt s -> GenSt t
-
-  -- | Determine whether we can terminate the generation of action.
-  canTerminate :: GenSt t -> Bool

--- a/executable-spec/test/Test/Cardano/Ledger/Update/Data.hs
+++ b/executable-spec/test/Test/Cardano/Ledger/Update/Data.hs
@@ -12,6 +12,7 @@ module Test.Cardano.Ledger.Update.Data
   , Endorser (MockEndorser)
   , Protocol (MockProtocol, mpProtocolId, mpProtocolVersion, mpSupersedesId, mpSupersedesVersion)
   , Id (ProtocolId, AppId, EndorserId, MPId)
+  , nextId
   , Version (Version)
   , ImplInfo (ImplInfo, mockImplements, mockImplType)
     -- * Re-exports from @MockProposal@
@@ -23,6 +24,7 @@ module Test.Cardano.Ledger.Update.Data
   , MockProposal.addToId
   , MockProposal.Vote (MockVote)
   , MockProposal.Voter (MockVoter)
+  , MockProposal.unParticipantId
   , MockProposal.mkParticipant
   )
 where
@@ -97,6 +99,11 @@ instance Identifiable (Protocol MockImpl) where
     deriving (Eq, Ord, Show)
 
   _id = mpProtocolId
+
+nextId :: Id (Protocol MockImpl) -> Id (Protocol MockImpl)
+nextId (ProtocolId i)
+  | i == maxBound = error "Maximum number of id's was reached."
+  | otherwise     = ProtocolId (i + 1)
 
 instance Identifiable (Application MockImpl) where
   data Id (Application MockImpl) = AppId Word64

--- a/executable-spec/test/Test/Cardano/Ledger/Update/Data/MockProposal.hs
+++ b/executable-spec/test/Test/Cardano/Ledger/Update/Data/MockProposal.hs
@@ -48,13 +48,13 @@ instance Show payload => Proposal (MockProposal prop payload) where
     MockSubmission
     { mpSubmissionCommit            :: MockCommit
     , mpSubmissionSignatureVerifies :: Bool
-    } deriving (Eq, Show)
+    } deriving (Eq, Ord, Show)
 
   data Revelation (MockProposal prop payload) =
     MockRevelation
     { refersTo :: MockCommit
     , reveals  :: MockProposal prop payload
-    } deriving (Eq, Show)
+    } deriving (Eq, Ord, Show)
 
   revelationCommit = mpSubmissionCommit
 
@@ -82,7 +82,7 @@ instance Show payload => Proposal (MockProposal prop payload) where
 --------------------------------------------------------------------------------
 
 instance Identifiable Participant where
-  newtype Id Participant = ParticipantId Word64
+  newtype Id Participant = ParticipantId { unParticipantId :: Word64 }
     deriving (Eq, Ord, Show)
 
   _id (Participant pId) = pId

--- a/executable-spec/test/Test/Cardano/Ledger/Update/Interface.hs
+++ b/executable-spec/test/Test/Cardano/Ledger/Update/Interface.hs
@@ -33,8 +33,7 @@ import           Cardano.Ledger.Update.Env.TracksSlotTime (TracksSlotTime,
                      currentSlot, epochFirstSlot, nextEpochFirstSlot,
                      stableAfter, stableAt)
 import qualified Cardano.Ledger.Update.Env.TracksSlotTime as SlotTime
-import           Cardano.Ledger.Update.ProposalState (VotingPeriod)
-import           Cardano.Ledger.Update.ProposalState (Decision)
+import           Cardano.Ledger.Update.ProposalsState (Decision, VotingPeriod)
 
 import qualified Cardano.Ledger.Update as Update
 
@@ -85,7 +84,7 @@ iStateProtocolVersion :: (Implementation sip impl) => IState sip impl -> Version
 iStateProtocolVersion = version . iStateCurrentVersion
 
 iStateCurrentVersion :: Implementation sip impl => IState sip impl -> Protocol impl
-iStateCurrentVersion = Update.getCurrentVersion . updateSt
+iStateCurrentVersion = Update.getCurrentProtocol . updateSt
 
 -- | At which slot is will the current slot (according to the given state)
 -- become stable.
@@ -176,7 +175,7 @@ tickTill desiredSlot st
     error "target slot should be less or equal than the current slot"
   where
     nextSlot = iStateCurrentSlot st + 1
-    st'  = SlotTime.checkInvariants
+    st'      = SlotTime.checkInvariants
              $ st { iStateCurrentSlot    = nextSlot
                   , iStateEpochFirstSlot =
                       if nextEpochFirstSlot st <= nextSlot
@@ -222,14 +221,13 @@ data UpdateState
   | ActivationExpired
   | ActivationCanceled
   | ActivationUnsupported
+  | Obsoleted
   | BeingEndorsed
   | HasEnoughEndorsements
   | Scheduled
   | Activated
   | Canceled
   deriving (Eq, Show, Generic)
-
-
 
 data PhaseState
   = Submitted

--- a/executable-spec/test/Test/Cardano/Ledger/Update/Properties.hs
+++ b/executable-spec/test/Test/Cardano/Ledger/Update/Properties.hs
@@ -1,0 +1,734 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Cardano.Ledger.Update.Properties where
+
+import           Control.Arrow (first, second, (***))
+import           Data.Map.Strict (Map)
+import           Data.Maybe (catMaybes)
+import           Data.Word (Word64)
+import           Test.Tasty (TestTree)
+import           Test.Tasty.QuickCheck (testProperty)
+
+-- TODO: import explicitly
+import           Control.Applicative.Successors (Succs (Succs), getSuccs)
+import           Test.QuickCheck (Arbitrary, Gen, arbitrary, choose, elements,
+                     expectFailure, frequency, oneof, shrink, shrinkList,
+                     vectorOf, withMaxSuccess)
+
+import qualified Data.Map.Strict as Map
+
+import           Cardano.Slotting.Block (BlockNo (BlockNo), unBlockNo)
+import           Cardano.Slotting.Slot (SlotNo (SlotNo), unSlotNo)
+
+import           Cardano.Ledger.Assert (allUnique, assertAndReturn, prettyShow)
+
+import           Cardano.Ledger.Update.Env.StakeDistribution (Stake (Stake),
+                     StakeDistribution, getStake)
+import           Cardano.Ledger.Update.Env.TracksSlotTime (currentSlot)
+import           Cardano.Ledger.Update.Proposal
+import           Cardano.Ledger.Update.ProposalsState
+                     (Decision (Approved, Expired, Rejected, WithNoQuorum),
+                     VotingPeriod (VotingPeriod), unVotingPeriod)
+
+import qualified Cardano.Ledger.Update as Update
+import qualified Cardano.Ledger.Update.Env.StakeDistribution as StakeDistribution
+import qualified Cardano.Ledger.Update.Proposal as Proposal
+
+import           Properties
+import           SUTTest
+import           Test.Cardano.Ledger.Update.Data
+import           Test.Cardano.Ledger.Update.Interface
+import           Test.Cardano.Ledger.UpdateSpec
+
+-- TODO: we wouldn't need this if @IState@ was not polymorphic. This import is
+-- needed only to bring the @HasStakeDistribution@ instance into scope. So
+-- consider making @IState@ monomorphic.
+import           Test.Cardano.Ledger.Update.TestCase ()
+
+
+runTests :: [TestTree]
+runTests = [
+           ---------------------------------------------------------------------
+           -- Ideation phase liveness properties
+           ---------------------------------------------------------------------
+             testProperty "SIP's are expired"
+             $ expectFailure
+             $ tracePropShow (sipsAreNot Expired)
+                             showActionsAndStateOfUpdateSpec
+           , testProperty "SIP's are rejected"
+             $ expectFailure
+             $ tracePropShow (sipsAreNot Rejected)
+                             showActionsAndStateOfUpdateSpec
+           , testProperty "SIP's get no-quorum"
+             $ expectFailure
+             $ tracePropShow (sipsAreNot WithNoQuorum)
+                             showActionsAndStateOfUpdateSpec
+           , testProperty "SIP's are approved"
+             $ expectFailure
+             $ tracePropShow (sipsAreNot Approved)
+                             showActionsAndStateOfUpdateSpec
+           ---------------------------------------------------------------------
+           -- Implementation phase liveness properties
+           ---------------------------------------------------------------------
+           , testProperty "Implementations are expired"
+             $ expectFailure
+             $ tracePropShow (implsAreNot Expired)
+                             showActionsAndStateOfUpdateSpec
+           , testProperty "Implementations are rejected"
+             $ expectFailure
+             $ withMaxSuccess 100
+             $ tracePropShow (implsAreNot Rejected)
+                             showActionsAndStateOfUpdateSpec
+           , testProperty "Implementations get no-quorum"
+             $ expectFailure
+             $ tracePropShow (implsAreNot WithNoQuorum)
+                             showActionsAndStateOfUpdateSpec
+           -- We do not test that implementations are approved since that is
+           -- implicitly tested when we test that updates are activated.
+           ---------------------------------------------------------------------
+           -- Activation phase liveness properties
+           ---------------------------------------------------------------------
+           , testProperty "Implementations are activated"
+             $ expectFailure
+             $ tracePropShow updatesAreNotActivated
+                             showActionsAndStateOfUpdateSpec
+           , testProperty "Implementations are queued"
+             $ expectFailure
+             $ tracePropShow updatesAreNotQueued
+                             showActionsAndStateOfUpdateSpec
+           , testProperty "Updates are discarded due to being expired"
+             $ expectFailure
+             $ tracePropShow (updatesAreNotDiscardedDueToBeing Update.Expired)
+                             showActionsAndStateOfUpdateSpec
+           , testProperty "Updates are discarded due to being unsupported"
+             $ expectFailure
+             $ withMaxSuccess 10000
+             $ tracePropShow (updatesAreNotDiscardedDueToBeing Update.Unsupported)
+                             showActionsAndStateOfUpdateSpec
+           , testProperty "Updates are discarded due to being obsoleted"
+             $ expectFailure
+             $ withMaxSuccess 10000
+             $ tracePropShow (updatesAreNotDiscardedDueToBeing Update.Obsoleted)
+                             showActionsAndStateOfUpdateSpec
+           ---------------------------------------------------------------------
+           -- Update system safety properties
+           ---------------------------------------------------------------------
+           -- , testProperty "Approved SIP's meet the adoption threshold"
+           --   $ traceProp prop_approvedSIPsHaveEnoughVotes
+
+           -- TODO: scheduled proposals cannot be canceled.
+           ---------------------------------------------------------------------
+           -- Coverage testing
+           ---------------------------------------------------------------------
+           -- TODO: test that the cases below are generated:
+           -- - SIP's and implementations got approved in the second voting period.
+           -- - SIP's and implementations got approved in the last voting period.
+           -- - protocol updates got canceled:
+           --   - before approval
+           --   - when the update was waiting in the queue
+           --   - when the update was a candidate
+           -- - protocol updated is adopted after being endorsed across several
+           --   epochs.
+           ]
+
+--------------------------------------------------------------------------------
+-- Definition of the system under test interface
+--------------------------------------------------------------------------------
+
+data UpdateSUT
+
+instance SUT UpdateSUT where
+
+  newtype SUTSt UpdateSUT = UpdateSt { unUpdateSt :: IState MockSIP MockImpl }
+    deriving (Show)
+
+  data SUTAct UpdateSUT
+    = TickAct SlotNo
+    -- ^ The slot number determines how many slots to tick, relative to the
+    -- current slot, which is known to the @apply@ function.
+    | UpdateAct (Update.Payload MockSIP MockImpl)
+    -- TODO: we need actions to update the environment: in particular an action
+    -- for changing the stake.
+    deriving (Show)
+
+  apply sutAct (UpdateSt st)
+    = either (const Nothing) (Just . UpdateSt)
+    $ case sutAct of
+        TickAct slot      -> slotTick (currentSlot st + slot) st
+        UpdateAct payload -> applyUpdate payload st
+        -- TODO: here we need a case for applying a stake change.
+
+instance Update.HasIdeationState (SUTSt UpdateSUT) MockSIP where
+  getIdeationState (UpdateSt st) = Update.getIdeationState st
+
+instance Update.HasApprovalState (SUTSt UpdateSUT) MockImpl where
+  getApprovalState (UpdateSt st) = Update.getApprovalState st
+
+instance Update.HasActivationState (SUTSt UpdateSUT) MockSIP MockImpl where
+  getActivationState (UpdateSt st) = Update.getActivationState st
+
+--------------------------------------------------------------------------------
+-- Definition of the update test generator
+--------------------------------------------------------------------------------
+
+data UpdateTestGen
+
+instance TestGen UpdateSUT UpdateTestGen where
+  data TestSetup UpdateTestGen =
+    UpdateTestSetup
+    { tsK                     :: !BlockNo
+    , tsMaxVotingPeriods      :: !VotingPeriod
+    , tsCurrentSlot           :: !SlotNo
+    , tsSlotsPerEpoch         :: !SlotNo
+    , tsAdversarialStakeRatio :: !Float
+    , tsParticipants          :: !(Map Participant Stake)
+    -- ^ The participants have an initial stake associated to them, which we use
+    -- to elaborate an initial state distribution. We have a single stake
+    -- distribution, which we will use for all experts (SIP and implementation)
+    -- as well as for stakepools.
+    , tsGenesisProtocol       :: !(Protocol MockImpl)
+    , tsUpdateProposals       :: ![ProposalScenario]
+    } deriving (Eq, Show)
+
+  data GenSt UpdateTestGen =
+    UpdateGenSt { unUpdateTestGen :: ![ProposalState] }
+    deriving (Show)
+
+  canTerminate =
+    all (finalState . genMode) . unUpdateTestGen
+
+
+  mkInitStates ts =
+    ( mkInitialGeneratorState ts
+    , UpdateSt (elaborateSUTInitialState ts)
+    )
+
+  update (UpdateGenSt states) (UpdateSt sutSt) =
+    UpdateGenSt $ fmap (updateGenSt sutSt) states
+
+  genAct setup (UpdateGenSt proposalsStates) = do
+    acts <- catMaybes <$> traverse (tryGenAct setup) proposalsStates
+    case acts of
+      [] -> pure $ TickAct 1
+            -- It was not possible to generate an action, so we need to generate
+            -- a slot tick. We tick with slot 1, since we do not want to miss
+            -- the slot ticks in the generators (otherwise a proposal that
+            -- should be approved might get expired).
+      _  -> frequency [ -- We want to make sure that time will pass regardless
+                        -- of whether actions can be generated for the proposals
+                        -- in the test setup. Remember that there will be
+                        -- invalid actions generated for the different
+                        -- proposals, so the chances of not generating an action
+                        -- might be quite low.
+                        (2, pure $! TickAct 1)
+                      , (8, elements acts)
+                      ]
+
+updateGenSt
+  :: IState MockSIP MockImpl
+  -> ProposalState
+  -> ProposalState
+updateGenSt sutSt proposalState =
+  proposalState
+  { genMode =
+      case stateOf updateSpec sutSt of
+        -- Ideation
+        SIP StablySubmitted         -> RevealingSIP
+        SIP StablyRevealed          -> VotingForSIP
+        SIP (IsStably Approved)     -> SubmittingImpl
+        SIP (IsStably Rejected)     -> Done
+        SIP (IsStably WithNoQuorum) -> Done
+        SIP (IsStably Expired)      -> Done
+        -- Implementation
+        Implementation StablySubmitted         -> RevealingImpl
+        Implementation StablyRevealed          -> VotingForImpl
+        -- Note that an approved implementation goes to the activation phase,
+        -- where it can enter the queue, the endorsement period, or be
+        -- discarded.
+        Implementation (IsStably Rejected)     -> Done
+        Implementation (IsStably WithNoQuorum) -> Done
+        Implementation (IsStably Expired)      -> Done
+        -- Activation
+        Activated             -> Done
+        BeingEndorsed         -> Endorsing
+        Queued                -> Waiting
+        ActivationExpired     -> Done
+        ActivationCanceled    -> Done
+        ActivationUnsupported -> Done
+        Obsoleted             -> Done
+        -- Otherwise stay in the same mode.
+        _ -> genMode proposalState
+
+  }
+  where
+    updateSpec = spec (scenario proposalState)
+
+tryGenAct
+  :: TestSetup UpdateTestGen -> ProposalState -> Gen (Maybe (SUTAct UpdateSUT))
+tryGenAct setup st
+  | genMode st == Done = pure Nothing
+  | otherwise          =  oneof [ randomAction setup st
+                                , bestEffortGenerator setup st
+                                ]
+
+randomAction
+  :: TestSetup UpdateTestGen -> ProposalState -> Gen (Maybe (SUTAct UpdateSUT))
+randomAction setup st
+  = fmap Just
+  $ oneof [ genSIPSubmission st
+          , genSIPRevelation st
+          , genSIPVote setup st
+          ]
+
+genSIPSubmission :: ProposalState ->  Gen (SUTAct UpdateSUT)
+genSIPSubmission st =
+  pure $! UpdateAct . Update.Ideation . Proposal.Submit
+       $! getSIPSubmission
+       $  spec
+       $  scenario st
+
+genImplSubmission :: ProposalState ->  Gen (SUTAct UpdateSUT)
+genImplSubmission st =
+  pure $! UpdateAct . Update.Approval . Proposal.Submit
+       $! getImplSubmission
+       $  spec
+       $  scenario st
+
+genSIPRevelation :: ProposalState -> Gen (SUTAct UpdateSUT)
+genSIPRevelation st =
+  pure $! UpdateAct . Update.Ideation . Proposal.Reveal
+       $! getSIPRevelation
+       $  spec
+       $  scenario st
+
+genImplRevelation :: ProposalState -> Gen (SUTAct UpdateSUT)
+genImplRevelation st =
+  pure $! UpdateAct . Update.Approval . Proposal.Reveal
+       $! getImplRevelation
+       $  spec
+       $  scenario st
+
+genSIPVote :: TestSetup UpdateTestGen -> ProposalState -> Gen (SUTAct UpdateSUT)
+genSIPVote setup st = do
+  participant  <- fmap MockVoter $ elements $ Map.keys $ tsParticipants setup
+  vConfidence  <- frequency $ confidenceFrequenciesFor
+                            $ sipVotersBehavior
+                            $ scenario st
+  voteVerifies <- frequency [(8, pure True), (2, pure False)]
+  pure $! UpdateAct . Update.Ideation . Proposal.Cast
+       $! MockVote (_id participant) (_id sip) vConfidence voteVerifies
+  where
+    sip = getSIP $ spec $ scenario st
+
+genImplVote :: TestSetup UpdateTestGen -> ProposalState -> Gen (SUTAct UpdateSUT)
+genImplVote setup st = do
+  participant  <- fmap MockVoter $ elements $ Map.keys $ tsParticipants setup
+  vConfidence  <- frequency $ confidenceFrequenciesFor
+                            $ implVotersBehavior
+                            $ scenario st
+  voteVerifies <- frequency [(8, pure True), (2, pure False)]
+  pure $! UpdateAct . Update.Approval . Proposal.Cast
+       $! MockVote (_id participant) (_id impl) vConfidence voteVerifies
+  where
+    impl = getImpl $ spec $ scenario st
+
+genMaybeEndorsement
+  :: TestSetup UpdateTestGen -> ProposalState -> Gen (Maybe (SUTAct UpdateSUT))
+genMaybeEndorsement setup st =
+  frequency [ (yes, fmap Just genEndorsement)
+            , (no , pure Nothing)
+            ]
+  where
+    (yes, no)      = endorsementFrequency $ endorsersBehavior $ scenario st
+    genEndorsement = do
+      endorser <- fmap MockEndorser $ elements $ Map.keys $ tsParticipants setup
+      pure $! UpdateAct . Update.Activation
+           $! Update.Endorsement
+              { Update.endorserId      = _id endorser
+              , Update.endorsedVersion = protocolVersion $ spec $ scenario st
+              }
+
+bestEffortGenerator
+  :: TestSetup UpdateTestGen -> ProposalState -> Gen (Maybe (SUTAct UpdateSUT))
+bestEffortGenerator setup st =
+  case genMode st of
+    SubmittingSIP -> fmap Just (genSIPSubmission st)
+    RevealingSIP  -> fmap Just (genSIPRevelation st)
+    VotingForSIP  -> fmap Just (genSIPVote setup st)
+    -- Implementation
+    SubmittingImpl -> fmap Just (genImplSubmission st)
+    RevealingImpl  -> fmap Just (genImplRevelation st)
+    VotingForImpl  -> fmap Just (genImplVote setup st)
+    -- Activation
+    Endorsing      -> genMaybeEndorsement setup st
+    Waiting        -> pure Nothing
+    Done           -> pure Nothing
+
+mkInitialGeneratorState
+  :: TestSetup UpdateTestGen -> GenSt UpdateTestGen
+mkInitialGeneratorState ts =
+  UpdateGenSt $ fmap idleProposalState $ tsUpdateProposals ts
+  where
+    idleProposalState someScenario =
+      ProposalState
+      { scenario = someScenario
+      , genMode  = SubmittingSIP
+      }
+
+elaborateSUTInitialState
+  :: TestSetup UpdateTestGen -> IState MockSIP MockImpl
+elaborateSUTInitialState ts =
+  IState
+  { iStateK                      = tsK ts
+  , iStateMaxVotingPeriods       = tsMaxVotingPeriods ts
+  , iStateSIPStakeDist           = elaborateStakeDist MockVoter ts
+  , iStateImplStakeDist          = elaborateStakeDist MockVoter ts
+  , iStateStakepoolsDistribution = elaborateStakeDist MockEndorser ts
+  , iStateCurrentSlot            = tsCurrentSlot ts
+  , iStateEpochFirstSlot         = tsCurrentSlot ts
+  , iStateSlotsPerEpoch          = tsSlotsPerEpoch ts
+  , iStateR_a                    = tsAdversarialStakeRatio ts
+  , updateSt                     = Update.initialState (tsGenesisProtocol ts)
+  }
+
+elaborateStakeDist
+  :: Identifiable a
+  => (Participant -> a)
+  -> TestSetup UpdateTestGen
+  -> StakeDistribution (Id a)
+elaborateStakeDist fParticipant ts
+  = StakeDistribution.fromList
+  $ fmap (first (_id . fParticipant))
+  $ Map.toList
+  $ tsParticipants ts
+
+--------------------------------------------------------------------------------
+-- Generator state supporting definitions
+--------------------------------------------------------------------------------
+
+data ProposalScenario =
+  ProposalScenario
+  { spec               :: !UpdateSpec
+  , sipVotersBehavior  :: !VotersBehavior
+  , implVotersBehavior :: !VotersBehavior
+  , endorsersBehavior  :: !EndorsersBehavior
+  } deriving (Eq, Show)
+
+data VotersBehavior
+  = MostReject
+  | MostAbstain
+  | MostApprove
+  | Uniform
+  -- ^ There is an equal probability that a voter decides to reject, abstain, or
+  -- approve a proposal.
+  deriving (Eq, Show)
+
+genVotersBehavior :: Gen VotersBehavior
+genVotersBehavior = elements [ MostReject, MostAbstain, MostApprove, Uniform ]
+
+confidenceFrequenciesFor :: VotersBehavior -> [(Int, Gen Proposal.Confidence)]
+confidenceFrequenciesFor MostReject
+  = [ (2, pure For)
+    , (7, pure Against)
+    , (1, pure Abstain)
+    ]
+confidenceFrequenciesFor MostAbstain
+  = [ (2, pure For)
+    , (1, pure Against)
+    , (7, pure Abstain)
+    ]
+confidenceFrequenciesFor MostApprove
+  = [ (7, pure For)
+    , (2, pure Against)
+    , (1, pure Abstain)
+    ]
+confidenceFrequenciesFor Uniform
+  = [ (1, pure For)
+    , (1, pure Against)
+    , (1, pure Abstain)
+    ]
+
+data EndorsersBehavior
+  = MostEndorse
+  | MostDoNotEndorse
+  | EqualEndorsementChance
+  -- ^ Given an endorser there is an equal probability that it endorses as that
+  -- it does not.
+  deriving (Eq, Show)
+
+genEndorsersBehavior :: Gen EndorsersBehavior
+genEndorsersBehavior = elements [ MostEndorse
+                                , MostDoNotEndorse
+                                , EqualEndorsementChance
+                                ]
+
+-- | Given an endorsers behavior, return a tuple where the first component is
+-- the endorsement generator weight (see @frequency@), and the second component
+-- is the no-endorsement generator weight.
+endorsementFrequency :: EndorsersBehavior -> (Int, Int)
+endorsementFrequency MostEndorse            = (8, 2)
+endorsementFrequency MostDoNotEndorse       = (2, 8)
+endorsementFrequency EqualEndorsementChance = (1, 1)
+
+data ProposalState =
+  ProposalState
+  { scenario :: !ProposalScenario
+  , genMode  :: !GenMode
+  } deriving (Show)
+
+-- | State of the generator for a single proposal.
+data GenMode
+  = SubmittingSIP
+  | RevealingSIP
+  | VotingForSIP
+  | SubmittingImpl
+  | RevealingImpl
+  | VotingForImpl
+  | Endorsing
+  | Waiting
+  | Done
+  deriving (Eq, Show)
+
+finalState :: GenMode -> Bool
+finalState Done    = True
+finalState Waiting = True -- The waiting state is a final state in the sense
+                          -- that if all other proposals are done or waiting,
+                          -- then there is no further action that can be taken
+                          -- and the generation should terminate.
+finalState _       = False
+
+--------------------------------------------------------------------------------
+-- Test setup generations
+--------------------------------------------------------------------------------
+
+instance Arbitrary (TestSetup UpdateTestGen) where
+  arbitrary = do
+    k   <- frequency [ (8, choose (1, 5))
+                     -- , (2, ???) -- TODO: what is the maximum value we should test with?
+                     ]
+    mvp <- VotingPeriod <$> choose (1, 4)
+    cs  <- SlotNo <$> choose (0, 10)
+    spe <- SlotNo <$> choose (1, k * 10)
+    ra  <- choose (0.00, 0.35)
+    ps <- genInitialStake
+    gp  <- genGenesisProtocol
+    ups <- genProposalScenarios gp (Map.keys ps)
+    pure $ UpdateTestSetup
+           { tsK                     = BlockNo k
+           , tsMaxVotingPeriods      = mvp
+           , tsCurrentSlot           = cs
+           , tsSlotsPerEpoch         = spe
+           , tsAdversarialStakeRatio = ra
+           , tsParticipants          = ps
+           , tsGenesisProtocol       = gp
+           , tsUpdateProposals       = assertAndReturn (allIdsAreDifferent gp)
+                                                       ups
+           }
+      where
+        allIdsAreDifferent gp scenarios = do
+          allUnique $ fmap (getUpdateSpecId . spec) scenarios
+          allUnique $ fmap (getSIPSubmission . spec) scenarios
+          allUnique $ fmap (getSIPRevelation . spec) scenarios
+          allUnique $ fmap (getImplSubmission . spec) scenarios
+          allUnique $ fmap (mpId . getImpl . spec) scenarios
+          allUnique $  fmap (_id . getProtocol . spec) scenarios
+                    ++ [mpProtocolId gp]
+
+  shrink ts
+    = getSuccs
+    $ UpdateTestSetup
+    <$> Succs (tsK ts)
+              (fmap BlockNo
+               $ filter (/= 0)
+               $ shrink
+               $ unBlockNo
+               $ tsK ts
+              )
+    <*> Succs (tsMaxVotingPeriods ts)
+              (fmap VotingPeriod
+               $ filter (/= 0)
+               $ shrink
+               $ unVotingPeriod
+               $ tsMaxVotingPeriods ts
+              )
+    <*> Succs (tsCurrentSlot ts)
+              (fmap SlotNo
+              $ shrink
+              $ unSlotNo
+              $ tsCurrentSlot ts
+              )
+    <*> Succs (tsSlotsPerEpoch ts)
+              (fmap SlotNo
+              $ filter (/= 0)
+              $ shrink
+              $ unSlotNo
+              $ tsSlotsPerEpoch ts
+              )
+    <*> elemAndShrinks (tsAdversarialStakeRatio ts)
+    <*> Succs (tsParticipants ts)
+              (fmap (Map.fromList . fmap (mkParticipant *** Stake))
+              $ filter (not . null)
+              $ shrink
+              $ fmap ((unParticipantId . _id) *** getStake)
+              $ Map.toList
+              $ tsParticipants ts
+              )
+    <*> pure (tsGenesisProtocol ts)
+    <*> Succs (tsUpdateProposals ts)
+              (filter (not . null)
+               $ shrinkList shrinkProposalScenario (tsUpdateProposals ts)
+              )
+
+shrinkProposalScenario :: ProposalScenario -> [ProposalScenario]
+shrinkProposalScenario aScenario =
+  [ aScenario { spec = spec'} | spec' <- shrinkUpdateSpec (spec aScenario)]
+
+shrinkUpdateSpec :: UpdateSpec -> [UpdateSpec]
+shrinkUpdateSpec aSpec
+  = getSuccs
+  $ (\sipVpd implVpd ->
+    aSpec { getSIPRevelation = (getSIPRevelation aSpec)
+                               { reveals = (reveals (getSIPRevelation aSpec))
+                                           { mpVotingPeriodDuration = SlotNo sipVpd }
+                               }
+          , getImplRevelation = (getImplRevelation aSpec)
+                                { reveals = (reveals (getImplRevelation aSpec))
+                                            { mpVotingPeriodDuration = SlotNo implVpd }
+                                }
+          }
+    )
+  <$> (elemAndShrinks $ unSlotNo $ votingPeriodDuration $ getSIP aSpec)
+  <*> (elemAndShrinks $ unSlotNo $ votingPeriodDuration $ getImpl aSpec)
+
+elemAndShrinks :: Arbitrary a => a -> Succs a
+elemAndShrinks a = Succs a (shrink a)
+
+-- | Generate an initial stake distribution.
+genInitialStake :: Gen (Map Participant Stake)
+genInitialStake = do
+  numParticipants  <- choose (1, 10)
+  let participants =  fmap mkParticipant [1, numParticipants]
+  stakes           <- vectorOf (fromIntegral numParticipants) genStake
+  pure $ Map.fromList
+       $ zip participants stakes
+  where
+    genStake = StakeDistribution.Stake <$> choose (1, 5)
+
+genGenesisProtocol :: Gen (Protocol MockImpl)
+genGenesisProtocol =
+  -- NOTE: we start always from zero. I cannot imagine the genesis protocol
+  -- having influence in the update mechanism behavior, so I rather keep things
+  -- simple (in this way we don't need to shrink the genesis protocol).
+  pure $ MockProtocol
+         { mpProtocolId        = ProtocolId 0
+         , mpProtocolVersion   = Version 0
+         , mpSupersedesId      = ProtocolId 0
+         , mpSupersedesVersion = Version 0
+         }
+
+genProposalScenarios
+  :: Protocol MockImpl
+  -> [Participant]
+  -> Gen [ProposalScenario]
+genProposalScenarios genesisProtocol participants = do
+  numUpdates <- choose (1, 20 :: Word64)
+  genUpdates numUpdates (nextId (mpSupersedesId genesisProtocol)) [genesisProtocol] []
+  where
+    genUpdates 0 _             _         acc  = pure acc
+    genUpdates n nextProtocolId protocols acc = do
+      sipAuthor          <- elements participants
+      implAuthor         <- elements participants
+      supersedesProtocol <- elements protocols
+      -- TODO: we should test that non-increasing versions are rejected. For
+      -- this we could decrease the version in some cases, instead of always
+      -- increasing it.
+      versionIncrement     <- choose (1, 5)
+      aSipVotersBehavior   <- genVotersBehavior
+      anImplVotersBehavior <- genVotersBehavior
+      anEndorsersBehavior  <- genEndorsersBehavior
+      votingDuration       <- choose (0, 10)
+      let
+         ProtocolId i   = nextProtocolId
+         nextVersion    =
+           mpProtocolVersion supersedesProtocol `increaseVersion` versionIncrement
+         updateSpec     =
+            dummyProtocolUpdateSpec i
+                                    sipAuthor
+                                    implAuthor
+                                    supersedesProtocol
+                                    nextVersion
+                                    (SlotNo votingDuration)
+         protocolUpdate = getProtocol updateSpec
+         proposalScenario =
+           ProposalScenario
+           { spec               = updateSpec
+           , sipVotersBehavior  = aSipVotersBehavior
+           , implVotersBehavior = anImplVotersBehavior
+           , endorsersBehavior  = anEndorsersBehavior
+           }
+      genUpdates (n - 1) (nextId nextProtocolId) (protocolUpdate:protocols) (proposalScenario:acc)
+
+--------------------------------------------------------------------------------
+-- Liveness properties
+--------------------------------------------------------------------------------
+
+sipsAreNot :: Decision -> Trace UpdateSUT UpdateTestGen -> Bool
+sipsAreNot decision =
+  updatesAreNot getSIPId (\sipId st -> Update.isSIP sipId decision st)
+
+implsAreNot :: Decision -> Trace UpdateSUT UpdateTestGen -> Bool
+implsAreNot decision =
+  updatesAreNot getImplId (\iid st -> Update.isImplementation iid decision st)
+
+updatesAreNotActivated :: Trace UpdateSUT UpdateTestGen -> Bool
+updatesAreNotActivated = updatesAreNot getProtocolId Update.isTheCurrentVersion
+
+updatesAreNotQueued :: Trace UpdateSUT UpdateTestGen -> Bool
+updatesAreNotQueued = updatesAreNot getProtocolId Update.isQueued
+
+updatesAreNotDiscardedDueToBeing
+  :: Update.Reason -> Trace UpdateSUT UpdateTestGen -> Bool
+updatesAreNotDiscardedDueToBeing reason =
+  updatesAreNot getProtocolId (\pid st -> Update.isDiscardedDueToBeing pid reason st)
+
+updatesAreNot
+  :: (UpdateSpec -> a)
+  -> (a -> SUTSt UpdateSUT -> Bool)
+  -> Trace UpdateSUT UpdateTestGen
+  -> Bool
+updatesAreNot updateSpecToA predA trace =
+  not $ any anyProtocolSatisfy (validStates trace)
+  where
+    anyProtocolSatisfy st = any (`predA` st) as
+    as                    = fmap (updateSpecToA . spec)
+                          $ tsUpdateProposals
+                          $ testSetup trace
+
+--------------------------------------------------------------------------------
+-- Safety properties
+--------------------------------------------------------------------------------
+
+-- | SIP's can get approved only if they have enough votes.
+--
+-- TODO: in a different property we can specify that a SIP can only get approved
+-- @stableAfter@ slots after the voting period ends.
+prop_approvedSIPsHaveEnoughVotes :: Trace UpdateSUT UpdateTestGen -> Bool
+prop_approvedSIPsHaveEnoughVotes = undefined
+
+--------------------------------------------------------------------------------
+-- Custom trace rendering
+--------------------------------------------------------------------------------
+
+-- | Show the actions and the state of the update specs in the test setup.
+showActionsAndStateOfUpdateSpec :: Trace UpdateSUT UpdateTestGen -> String
+showActionsAndStateOfUpdateSpec trace
+  =  prettyShow (testSetup trace)
+  ++ "\nInitial state: \n"
+  ++ prettyShow (stateOfSpecsAt (initialState trace))
+  ++ "\nEvents: \n"
+  ++ prettyShow (fmap (second stateOfSpecsAt) (validTransitions trace))
+  where
+    updateSpecs = fmap spec $ tsUpdateProposals $ testSetup trace
+    stateOfSpecsAt st = fmap (`stateOf` (unUpdateSt st)) updateSpecs

--- a/executable-spec/test/Test/Cardano/Ledger/Update/UnitTests/Activation.hs
+++ b/executable-spec/test/Test/Cardano/Ledger/Update/UnitTests/Activation.hs
@@ -26,7 +26,6 @@ import           Test.Cardano.Ledger.Update.UnitTests.Common
 import           Test.Cardano.Ledger.Update.UnitTests.Ideation
 
 import           Cardano.Ledger.Update.Proposal (Protocol, _id)
-import qualified Cardano.Ledger.Update.Proposal as Proposal
 
 import           Test.Cardano.Ledger.Update.Data
 
@@ -160,6 +159,7 @@ competingProposals = do
   approveImplementation update1
   stateOf update1 `shouldBe` BeingEndorsed
   activate update1
+  iStateProtocolVersion `shouldBe` protocolVersion update1
 
 queuedProposal :: TestCase
 queuedProposal = do
@@ -232,7 +232,7 @@ endorseTillApproval updateSpec = do
     mkEndorsement endorser
       = Update.Endorsement
         { Update.endorserId       = _id endorser
-        , Update.endorsedVersion = Proposal.version (getProtocol updateSpec)
+        , Update.endorsedVersion = protocolVersion updateSpec
         }
 
 getEndorsersForApproval :: TestCaseEnv -> [Endorser (Protocol MockImpl)]

--- a/executable-spec/test/Test/Cardano/Ledger/Update/UnitTests/Approval.hs
+++ b/executable-spec/test/Test/Cardano/Ledger/Update/UnitTests/Approval.hs
@@ -7,7 +7,8 @@ import           Data.Foldable (traverse_)
 import           Test.Tasty (TestTree)
 
 import           Cardano.Ledger.Update.Env.TracksSlotTime (stableAfter)
-import           Cardano.Ledger.Update.ProposalState (Decision (Approved, Expired, Rejected, Undecided, WithNoQuorum))
+import           Cardano.Ledger.Update.ProposalState
+                     (Decision (Approved, Expired, Rejected, WithNoQuorum))
 import qualified Cardano.Ledger.Update.ProposalState as ProposalState
 
 import           Test.Cardano.Ledger.Update.Interface
@@ -159,9 +160,9 @@ implApprovalInSecondVotingRound = do
   tickTillStable
   -- The tally point is reached. The implementation should not have enough
   -- votes.
-  stateOf update `shouldBe` (Implementation (Is Undecided))
+  stateOf update `shouldBe` Implementation StablyRevealed
   approve `implementation` update
-  stateOf update `shouldBe` Implementation (Is Undecided)
+  stateOf update `shouldBe` Implementation StablyRevealed
   tickFor $ Proposal.votingPeriodDuration (getImpl update)
   tickTillStable
   stateOf update `shouldBe` BeingEndorsed
@@ -186,7 +187,7 @@ implVotesAreNotCarriedOver = do
   vote approvers0 update Proposal.For
   tickFor $ Proposal.votingPeriodDuration (getImpl update)
   tickTillStable
-  stateOf update `shouldBe` (Implementation (Is Undecided))
+  stateOf update `shouldBe` Implementation StablyRevealed
   vote approvers1 update Proposal.For
   tickFor $ Proposal.votingPeriodDuration (getImpl update)
   tickTillStable
@@ -254,10 +255,10 @@ approveImplementation update = do
   submit `implementation` update
   tickTillStable
   reveal  `implementation` update
-  stateOf update `shouldBe` Implementation (Is Undecided)
+  stateOf update `shouldBe` Implementation Revealed
   tickTillStable
   approve `implementation` update
-  stateOf update `shouldBe` Implementation (Is Undecided)
+  stateOf update `shouldBe` Implementation StablyRevealed
   tickFor $ Proposal.votingPeriodDuration (getImpl update)
   tickTillStable
 

--- a/nix/.stack.nix/decentralized-updates.nix
+++ b/nix/.stack.nix/decentralized-updates.nix
@@ -66,6 +66,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
           (hsPkgs."cardano-slotting" or (buildDepError "cardano-slotting"))
           (hsPkgs."monad-validate" or (buildDepError "monad-validate"))
+          (hsPkgs."Unique" or (buildDepError "Unique"))
           (hsPkgs."mtl" or (buildDepError "mtl"))
           ];
         buildable = true;
@@ -82,6 +83,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."pretty-simple" or (buildDepError "pretty-simple"))
             (hsPkgs."text" or (buildDepError "text"))
             (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."successors" or (buildDepError "successors"))
             (hsPkgs."cardano-slotting" or (buildDepError "cardano-slotting"))
             (hsPkgs."decentralized-updates" or (buildDepError "decentralized-updates"))
             ];

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -10,12 +10,14 @@
         "canonical-json" = (((hackage.canonical-json)."0.6.0.0").revisions).default;
         "terminal-progress-bar" = (((hackage.terminal-progress-bar)."0.4.1").revisions)."ba857f3424ddb1034125163a9a384e9baab22e55de968259b046892c20ec0526";
         "monad-validate" = (((hackage.monad-validate)."1.2.0.0").revisions)."9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881";
+        "Unique" = (((hackage.Unique)."0.4.7.7").revisions)."2269d3528271e25d34542e7c24a4e541e27ec33460e1ea00845da95b82eec6fa";
         decentralized-updates = ./decentralized-updates.nix;
         datil = ./datil.nix;
         cardano-prelude = ./cardano-prelude.nix;
         cardano-binary = ./cardano-binary.nix;
         cardano-crypto-class = ./cardano-crypto-class.nix;
         cardano-slotting = ./cardano-slotting.nix;
+        successors = ./successors.nix;
         cardano-crypto = ./cardano-crypto.nix;
         };
       compiler.version = "8.6.5";

--- a/nix/.stack.nix/successors.nix
+++ b/nix/.stack.nix/successors.nix
@@ -1,0 +1,69 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "successors"; version = "0.1.0.1"; };
+      license = "MIT";
+      copyright = "2017 Joachim Breitner";
+      maintainer = "mail@joachim-breitner.de";
+      author = "Joachim Breitner";
+      homepage = "https://github.com/nomeata/haskell-successors";
+      url = "";
+      synopsis = "An applicative functor to manage successors";
+      description = "This package provides the\n'Control.Applicative.Successors.Succs' functor. It models\na node in a graph together with its successors. The\n@Applicative@ (and @Monad@) instances are designed so that\nthe successors of the resulting value take exactly one\nstep, either in the left or the right argument to @\\<*\\>@\n(or @>>=@).";
+      buildType = "Simple";
+      isLocal = true;
+      };
+    components = {
+      "library" = {
+        depends = [ (hsPkgs."base" or (buildDepError "base")) ];
+        buildable = true;
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/nomeata/haskell-successors";
+      rev = "6f9f60eb3232b83cbffdc46301054c85983cf207";
+      sha256 = "03jbs0730nyjhi01wqgmn6848pklvnzja7dv4nlhs1s6zb43gznx";
+      });
+    }

--- a/stack.yaml
+++ b/stack.yaml
@@ -30,6 +30,11 @@ extra-deps:
 
   # Needed for the assertions library
   - monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
+  - Unique-0.4.7.7@sha256:2269d3528271e25d34542e7c24a4e541e27ec33460e1ea00845da95b82eec6fa,2777
+
+  # Needed for shrinking of products
+  - git: https://github.com/nomeata/haskell-successors
+    commit: 6f9f60eb3232b83cbffdc46301054c85983cf207
 
 nix:
   shell-file: nix/stack-shell.nix


### PR DESCRIPTION
Define generators for protocol update events. These events cover the ideation, approval, and activation phases.

We only test a lot of important liveness properties at the moment:

- SIP's are expired
- SIP's are rejected
- SIP's get no-quorum
- SIP's are approved
- Implementations are expired
- Implementations are rejected
- Implementations get no-quorum
- Implementations are activated
- Implementations are queued
- Updates are discarded due to being expired
- Updates are discarded due to being unsupported
- Updates are discarded due to being obsoleted

In next iterations we will test safety properties such as:

- Updates are only approved by a majority.
- Protocol versions only change by monotonic increases.
